### PR TITLE
Fixing unhandled video promise

### DIFF
--- a/src/Carplay.js
+++ b/src/Carplay.js
@@ -56,13 +56,24 @@ function Carplay ({changeSetting, settings, ws, type, touchEvent, status, reload
 
         setHeight(height)
         setWidth(width)
+        
+        let videoElement
+        let playPromise
 
         if(type === 'ws') {
             ws.onmessage = (event) => {
                 if(!running) {
-                    let video = document.getElementById('player')
-                    video.play()
-                    setRunning(true)
+                    videoElement = document.getElementById('player')
+                    if(videoElement != null) {
+                        playPromise = videoElement.play()
+                        if(playPromise !== undefined) {
+                            setRunning(true)
+                            playPromise.then(_ => {
+                            })
+                            .catch(error => {
+                            });
+                        }
+                    }
                 }
                 let buf = Buffer.from(event.data)
                 let video = buf.slice(4)


### PR DESCRIPTION
This fix helped resolving the following errors when unmounting the carplay component:

```

Uncaught (in promise) DOMException: The play() request was interrupted because the media was removed from the document. https://goo.gl/LdLk22

Uncaught TypeError: Cannot read properties of null (reading 'play')
    at ws.onmessage (bundle.js:108985:17)  //This error is thrown over and over again, probably on every frame.
```

Details on this fix can be found here: https://goo.gl/LdLk22